### PR TITLE
PR#64 - [김대호] 회원, 직급, 부서 생성 유효성 검증, 엔티티 속성 추가, 메서드

### DIFF
--- a/front/src/app/auth/signin/page.tsx
+++ b/front/src/app/auth/signin/page.tsx
@@ -19,14 +19,20 @@ const SignIn: React.FC = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
 
+  // 로그인 상태일때, 홈으로 돌려 보냄.
+  if (queryClient.getQueryData(["member"]) !== undefined) {
+    alert("이미 로그인 상태 입니다.");
+    router.replace("/");
+  }
+
+  // 아이디, 비밀번호 입력 감지
   const loginFormHandleChange = (e: any) => {
     const { name, value } = e.target;
-    // const name: any = e.target.name;
-    // const value = e.target.value;
     setLoginForm({ ...loginForm, [name]: value });
     console.log({ ...loginForm, [name]: value });
   };
 
+  // 로그인 요청
   const login = async (e: any) => {
     e.preventDefault();
 

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -6,6 +6,7 @@ import "@/css/style.css";
 import React, { useEffect, useState } from "react";
 import Loader from "@/components/common/Loader";
 import ReactQueryProviders from "@/util/reactQueryProvider";
+import MeApiWithReactQuery from "@/components/Api/MeApiWithReactQuery";
 
 export default function RootLayout({
   children,
@@ -22,10 +23,11 @@ export default function RootLayout({
   }, []);
 
   return (
-    <html lang="en">
+    <html lang="ko">
       <body suppressHydrationWarning={true} className="h-screen">
         <ReactQueryProviders>
           <div className="dark:bg-boxdark-2 dark:text-bodydark">
+            <MeApiWithReactQuery />
             {loading ? <Loader /> : children}
           </div>
         </ReactQueryProviders>

--- a/front/src/components/Api/MeApiWithReactQuery.tsx
+++ b/front/src/components/Api/MeApiWithReactQuery.tsx
@@ -1,0 +1,29 @@
+import api from "@/util/api";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import Loader from "../common/Loader";
+
+export default function MeApiWithReactQuery() {
+  const queryClient = useQueryClient();
+  const getMember = async () => {
+    console.log("!!1141234313");
+    await api.get("/api/v1/members/me").then((res) => {
+      queryClient.setQueryData(["member"], res.data.data.memberDTO);
+    });
+  };
+  const { data, isLoading } = useQuery({
+    queryKey: ["member"],
+    queryFn: getMember,
+  });
+
+  if (isLoading) {
+    return (
+      <>
+        <Loader />
+      </>
+    );
+  }
+
+  if (data) {
+    return;
+  }
+}

--- a/front/src/components/Api/MeApiWithReactQuery.tsx
+++ b/front/src/components/Api/MeApiWithReactQuery.tsx
@@ -1,20 +1,24 @@
 import api from "@/util/api";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Loader from "../common/Loader";
+import { useRouter } from "next/navigation";
 
 export default function MeApiWithReactQuery() {
   const queryClient = useQueryClient();
+  const router = useRouter();
+
   const getMember = async () => {
-    console.log("!!1141234313");
     await api.get("/api/v1/members/me").then((res) => {
       queryClient.setQueryData(["member"], res.data.data.memberDTO);
     });
   };
+
   const { data, isLoading } = useQuery({
     queryKey: ["member"],
     queryFn: getMember,
   });
 
+  // 데이터 패칭 중
   if (isLoading) {
     return (
       <>
@@ -25,5 +29,10 @@ export default function MeApiWithReactQuery() {
 
   if (data) {
     return;
+  }
+
+  // 비 로그인 시 강제 이동
+  if (queryClient.getQueryData(["member"]) === undefined) {
+    router.replace("/auth/signin");
   }
 }

--- a/front/src/components/Layouts/DefaultLayout.tsx
+++ b/front/src/components/Layouts/DefaultLayout.tsx
@@ -2,6 +2,7 @@
 import React, { useState, ReactNode } from "react";
 import Sidebar from "@/components/Sidebar";
 import Header from "@/components/Header";
+import MeApiWithReactQuery from "../Api/MeApiWithReactQuery";
 
 export default function DefaultLayout({
   children,

--- a/front/src/util/api.ts
+++ b/front/src/util/api.ts
@@ -1,8 +1,24 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
+import { Loader } from "next/dynamic";
 
 const api = axios.create({
   baseURL: "http://localhost:8090",
   withCredentials: true,
+});
+
+axios.interceptors.request.use(function () {
+  const queryClient = useQueryClient();
+  const getMember = async () => {
+    console.log("!!1141234313");
+    await api.get("/api/v1/members/me").then((res) => {
+      queryClient.setQueryData(["member"], res.data.data.memberDTO);
+    });
+  };
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ["member"],
+    queryFn: getMember,
+  });
 });
 
 export default api;

--- a/front/src/util/api.ts
+++ b/front/src/util/api.ts
@@ -1,24 +1,8 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
-import { Loader } from "next/dynamic";
 
 const api = axios.create({
   baseURL: "http://localhost:8090",
   withCredentials: true,
-});
-
-axios.interceptors.request.use(function () {
-  const queryClient = useQueryClient();
-  const getMember = async () => {
-    console.log("!!1141234313");
-    await api.get("/api/v1/members/me").then((res) => {
-      queryClient.setQueryData(["member"], res.data.data.memberDTO);
-    });
-  };
-  const { data, isLoading, refetch } = useQuery({
-    queryKey: ["member"],
-    queryFn: getMember,
-  });
 });
 
 export default api;

--- a/src/main/java/com/app/businessBridge/domain/department/DTO/DepartmentDTO.java
+++ b/src/main/java/com/app/businessBridge/domain/department/DTO/DepartmentDTO.java
@@ -13,8 +13,8 @@ import java.util.List;
 public class DepartmentDTO {
 
     private Long id;
-    private Integer departmentCode;
-    private String departmentName;
+    private Integer code;
+    private String name;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
 
@@ -23,8 +23,8 @@ public class DepartmentDTO {
 
     public DepartmentDTO(Department department) {
         this.id = department.getId();
-        this.departmentCode = department.getDepartmentCode();
-        this.departmentName = department.getDepartmentName();
+        this.code = department.getCode();
+        this.name = department.getName();
         this.createdDate = department.getCreatedDate();
         this.modifiedDate = department.getModifiedDate();
     }

--- a/src/main/java/com/app/businessBridge/domain/department/controller/ApiV1DepartmentController.java
+++ b/src/main/java/com/app/businessBridge/domain/department/controller/ApiV1DepartmentController.java
@@ -27,8 +27,8 @@ public class ApiV1DepartmentController {
             return RsData.of(RsCode.F_10, "알 수 없는 오류로 실패했습니다.");
         }
 
-        RsData rsData = this.departmentService.create(createRequest.getDepartmentCode(),
-                createRequest.getDepartmentName());
+        RsData rsData = this.departmentService.create(createRequest.getCode(),
+                createRequest.getName());
 
         return RsData.of(rsData.getRsCode(), rsData.getMsg());
     }
@@ -50,8 +50,8 @@ public class ApiV1DepartmentController {
             return RsData.of(RsCode.F_10, "알 수 없는 오류로 실패했습니다.");
         }
 
-        RsData<Department> rsData = this.departmentService.update(updateRequest.getId(), updateRequest.getDepartmentCode(),
-                updateRequest.getDepartmentName());
+        RsData<Department> rsData = this.departmentService.update(updateRequest.getId(), updateRequest.getCode(),
+                updateRequest.getName());
 
         return RsData.of(rsData.getRsCode(), rsData.getMsg(), new DepartmentResponse.PatchedDepartment(rsData.getData()));
     }

--- a/src/main/java/com/app/businessBridge/domain/department/entity/Department.java
+++ b/src/main/java/com/app/businessBridge/domain/department/entity/Department.java
@@ -17,8 +17,8 @@ import lombok.experimental.SuperBuilder;
 public class Department extends BaseEntity {
 
     // 부서 코드
-    private Integer departmentCode;
+    private Integer code;
 
     // 부서명
-    private String departmentName;
+    private String name;
 }

--- a/src/main/java/com/app/businessBridge/domain/department/repository/DepartmentRepository.java
+++ b/src/main/java/com/app/businessBridge/domain/department/repository/DepartmentRepository.java
@@ -4,7 +4,10 @@ import com.app.businessBridge.domain.department.entity.Department;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DepartmentRepository extends JpaRepository<Department,Long> {
     List<Department> findAll();
+    Optional<Department> findByCode(Integer code);
+    Optional<Department> findByName(String name);
 }

--- a/src/main/java/com/app/businessBridge/domain/department/request/DepartmentRequest.java
+++ b/src/main/java/com/app/businessBridge/domain/department/request/DepartmentRequest.java
@@ -12,9 +12,9 @@ public class DepartmentRequest {
     @Setter
     public static class CreateRequest {
         @NotNull
-        private Integer departmentCode;
+        private Integer code;
         @NotBlank
-        private String departmentName;
+        private String name;
     }
 
     @Getter
@@ -23,9 +23,9 @@ public class DepartmentRequest {
         @NotNull
         private Long id;
         @NotNull
-        private Integer departmentCode;
+        private Integer code;
         @NotBlank
-        private String departmentName;
+        private String name;
     }
 
     @Getter

--- a/src/main/java/com/app/businessBridge/domain/department/service/DepartmentService.java
+++ b/src/main/java/com/app/businessBridge/domain/department/service/DepartmentService.java
@@ -16,10 +16,10 @@ public class DepartmentService {
     private final DepartmentRepository departmentRepository;
 
     // 부서 생성
-    public RsData create(Integer departmentCode, String departmentName) {
+    public RsData create(Integer code, String name) {
         Department department = Department.builder()
-                .departmentCode(departmentCode)
-                .departmentName(departmentName)
+                .code(code)
+                .name(name)
                 .build();
         this.departmentRepository.save(department);
 
@@ -34,7 +34,7 @@ public class DepartmentService {
     }
 
     // 부서 업데이트
-    public RsData<Department> update(Long id, Integer departmentCode, String departmentName) {
+    public RsData<Department> update(Long id, Integer code, String name) {
         RsData<Department> rsData = findById(id);
 
         if (rsData.getData() == null) {
@@ -42,8 +42,8 @@ public class DepartmentService {
         }
 
         Department department = rsData.getData().toBuilder()
-                .departmentCode(departmentCode)
-                .departmentName(departmentName)
+                .code(code)
+                .name(name)
                 .build();
 
         this.departmentRepository.save(department);

--- a/src/main/java/com/app/businessBridge/domain/department/service/DepartmentService.java
+++ b/src/main/java/com/app/businessBridge/domain/department/service/DepartmentService.java
@@ -17,6 +17,13 @@ public class DepartmentService {
 
     // 부서 생성
     public RsData create(Integer code, String name) {
+        // 중복 검사
+        if (this.departmentRepository.findByCode(code).isPresent()) {
+            return RsData.of(RsCode.F_06, "이미 존재하는 부서코드 입니다.");
+        } else if (this.departmentRepository.findByName(name).isPresent()) {
+            return RsData.of(RsCode.F_06, "이미 존재하는 부서명 입니다.");
+        }
+
         Department department = Department.builder()
                 .code(code)
                 .name(name)
@@ -35,10 +42,18 @@ public class DepartmentService {
 
     // 부서 업데이트
     public RsData<Department> update(Long id, Integer code, String name) {
+        // 부서 찾기
         RsData<Department> rsData = findById(id);
 
         if (rsData.getData() == null) {
-            return RsData.of(rsData.getRsCode(), rsData.getMsg(), null);
+            return rsData;
+        }
+
+        // 중복 검사
+        if (this.departmentRepository.findByCode(code).isPresent()) {
+            return RsData.of(RsCode.F_06, "이미 존재하는 부서코드 입니다.");
+        } else if (this.departmentRepository.findByName(name).isPresent()) {
+            return RsData.of(RsCode.F_06, "이미 존재하는 부서명 입니다.");
         }
 
         Department department = rsData.getData().toBuilder()
@@ -48,15 +63,16 @@ public class DepartmentService {
 
         this.departmentRepository.save(department);
 
-        return RsData.of(RsCode.S_03, "부서가 업데이트되었습니다.",department);
+        return RsData.of(RsCode.S_03, "부서가 업데이트되었습니다.", department);
     }
 
     // 부서 삭제
     public RsData delete(Long id) {
+        // 부서 찾기
         RsData<Department> rsData = findById(id);
-
+        // 없으면 그냥 리턴
         if (rsData.getData() == null) {
-            return RsData.of(rsData.getRsCode(), rsData.getMsg());
+            return rsData;
         }
 
         this.departmentRepository.delete(rsData.getData());

--- a/src/main/java/com/app/businessBridge/domain/grade/DTO/GradeDTO.java
+++ b/src/main/java/com/app/businessBridge/domain/grade/DTO/GradeDTO.java
@@ -13,8 +13,8 @@ import java.util.List;
 public class GradeDTO {
 
     private Long id;
-    private Integer gradeCode;
-    private String gradeName;
+    private Integer code;
+    private String name;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
 
@@ -23,8 +23,8 @@ public class GradeDTO {
 
     public GradeDTO(Grade grade) {
         this.id = grade.getId();
-        this.gradeCode = grade.getGradeCode();
-        this.gradeName = grade.getGradeName();
+        this.code = grade.getCode();
+        this.name = grade.getName();
         this.createdDate = grade.getCreatedDate();
         this.modifiedDate = grade.getModifiedDate();
     }

--- a/src/main/java/com/app/businessBridge/domain/grade/controller/ApiV1GradeController.java
+++ b/src/main/java/com/app/businessBridge/domain/grade/controller/ApiV1GradeController.java
@@ -26,8 +26,8 @@ public class ApiV1GradeController {
             return RsData.of(RsCode.F_10, "알 수 없는 오류로 실패했습니다.");
         }
 
-        RsData rsData = this.gradeService.create(createRequest.getGradeCode(),
-                createRequest.getGradeName());
+        RsData rsData = this.gradeService.create(createRequest.getCode(),
+                createRequest.getName());
 
         return RsData.of(rsData.getRsCode(), rsData.getMsg());
     }
@@ -49,8 +49,8 @@ public class ApiV1GradeController {
             return RsData.of(RsCode.F_10, "알 수 없는 오류로 실패했습니다.");
         }
 
-        RsData<Grade> rsData = this.gradeService.update(updateRequest.getId(), updateRequest.getGradeCode(),
-                updateRequest.getGradeName());
+        RsData<Grade> rsData = this.gradeService.update(updateRequest.getId(), updateRequest.getCode(),
+                updateRequest.getName());
 
         return RsData.of(rsData.getRsCode(), rsData.getMsg(), new GradeResponse.PatchedGrade(rsData.getData()));
     }

--- a/src/main/java/com/app/businessBridge/domain/grade/controller/ApiV1GradeController.java
+++ b/src/main/java/com/app/businessBridge/domain/grade/controller/ApiV1GradeController.java
@@ -38,7 +38,8 @@ public class ApiV1GradeController {
     public RsData<GradeResponse.GetGrades> getAll() {
         RsData<List<Grade>> rsData = this.gradeService.findAll();
 
-        return RsData.of(rsData.getRsCode(), rsData.getMsg(), new GradeResponse.GetGrades(rsData.getData()));
+        return RsData.of(rsData.getRsCode(), rsData.getMsg(),
+                new GradeResponse.GetGrades(rsData.getData()));
     }
 
     // 직급 수정

--- a/src/main/java/com/app/businessBridge/domain/grade/entity/Grade.java
+++ b/src/main/java/com/app/businessBridge/domain/grade/entity/Grade.java
@@ -17,9 +17,9 @@ import lombok.experimental.SuperBuilder;
 public class Grade extends BaseEntity {
 
     // 직급 코드
-    private Integer gradeCode;
+    private Integer code;
 
     // 직급명
-    private String gradeName;
+    private String name;
 
 }

--- a/src/main/java/com/app/businessBridge/domain/grade/repository/GradeRepository.java
+++ b/src/main/java/com/app/businessBridge/domain/grade/repository/GradeRepository.java
@@ -4,7 +4,10 @@ import com.app.businessBridge.domain.grade.entity.Grade;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface GradeRepository extends JpaRepository<Grade, Long> {
     List<Grade> findAll();
+    Optional<Grade> findByCode(Integer code);
+    Optional<Grade> findByName(String name);
 }

--- a/src/main/java/com/app/businessBridge/domain/grade/request/GradeRequest.java
+++ b/src/main/java/com/app/businessBridge/domain/grade/request/GradeRequest.java
@@ -12,9 +12,9 @@ public class GradeRequest {
     @Setter
     public static class CreateRequest {
         @NotNull
-        private Integer gradeCode;
+        private Integer code;
         @NotBlank
-        private String gradeName;
+        private String name;
     }
 
     @Getter
@@ -23,9 +23,9 @@ public class GradeRequest {
         @NotNull
         private Long id;
         @NotNull
-        private Integer gradeCode;
+        private Integer code;
         @NotBlank
-        private String gradeName;
+        private String name;
     }
 
     @Getter

--- a/src/main/java/com/app/businessBridge/domain/grade/service/GradeService.java
+++ b/src/main/java/com/app/businessBridge/domain/grade/service/GradeService.java
@@ -17,20 +17,27 @@ public class GradeService {
 
     // 직급 생성
     public RsData create(Integer code, String name) {
+        // 중복 검사
+        if (this.gradeRepository.findByCode(code).isPresent()) {
+            return RsData.of(RsCode.F_06, "이미 존재하는 직급코드 입니다.");
+        } else if (this.gradeRepository.findByName(name).isPresent()) {
+            return RsData.of(RsCode.F_06, "이미 존재하는 직급명 입니다.");
+        }
+
         Grade grade = Grade.builder()
                 .code(code)
                 .name(name)
                 .build();
         this.gradeRepository.save(grade);
 
-        return RsData.of(RsCode.S_02, "새로운 리소스가 성공적으로 생성되었습니다.");
+        return RsData.of(RsCode.S_02, "직급이 생성되었습니다.");
     }
 
     // 직급 모두 불러오기
     public RsData<List<Grade>> findAll() {
         List<Grade> gradeDTOList = this.gradeRepository.findAll();
 
-        return RsData.of(RsCode.S_05, "요청한 리소스목록을 찾았습니다.", gradeDTOList);
+        return RsData.of(RsCode.S_05, "직급목록을 찾았습니다.", gradeDTOList);
     }
 
     // 직급 업데이트
@@ -38,7 +45,14 @@ public class GradeService {
         RsData<Grade> rsData = findById(id);
 
         if (rsData.getData() == null) {
-            return RsData.of(rsData.getRsCode(), rsData.getMsg(), null);
+            return rsData;
+        }
+
+        // 중복 검사
+        if (this.gradeRepository.findByCode(code).isPresent()) {
+            return RsData.of(RsCode.F_06, "이미 존재하는 직급코드 입니다.");
+        } else if (this.gradeRepository.findByName(name).isPresent()) {
+            return RsData.of(RsCode.F_06, "이미 존재하는 직급명 입니다.");
         }
 
         Grade grade = rsData.getData().toBuilder()

--- a/src/main/java/com/app/businessBridge/domain/grade/service/GradeService.java
+++ b/src/main/java/com/app/businessBridge/domain/grade/service/GradeService.java
@@ -16,10 +16,10 @@ public class GradeService {
     private final GradeRepository gradeRepository;
 
     // 직급 생성
-    public RsData create(Integer gradeCode, String gradeName) {
+    public RsData create(Integer code, String name) {
         Grade grade = Grade.builder()
-                .gradeCode(gradeCode)
-                .gradeName(gradeName)
+                .code(code)
+                .name(name)
                 .build();
         this.gradeRepository.save(grade);
 
@@ -34,7 +34,7 @@ public class GradeService {
     }
 
     // 직급 업데이트
-    public RsData<Grade> update(Long id, Integer gradeCode, String gradeName) {
+    public RsData<Grade> update(Long id, Integer code, String name) {
         RsData<Grade> rsData = findById(id);
 
         if (rsData.getData() == null) {
@@ -42,8 +42,8 @@ public class GradeService {
         }
 
         Grade grade = rsData.getData().toBuilder()
-                .gradeCode(gradeCode)
-                .gradeName(gradeName)
+                .code(code)
+                .name(name)
                 .build();
 
         this.gradeRepository.save(grade);

--- a/src/main/java/com/app/businessBridge/domain/member/DTO/MemberDTO.java
+++ b/src/main/java/com/app/businessBridge/domain/member/DTO/MemberDTO.java
@@ -6,8 +6,6 @@ import com.app.businessBridge.domain.member.entity.Member;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Getter
 @NoArgsConstructor
 public class MemberDTO {

--- a/src/main/java/com/app/businessBridge/domain/member/Service/MemberService.java
+++ b/src/main/java/com/app/businessBridge/domain/member/Service/MemberService.java
@@ -39,6 +39,12 @@ public class MemberService {
         Optional<Department> od = this.departmentRepository.findByCode(departmentCode);
         Optional<Grade> og = this.gradeRepository.findByCode(gradeCode);
 
+        if (findByUsername(username).getData() != null) {
+            return RsData.of(RsCode.F_06, "중복된 아이디가 존재합니다.");
+        } else if (findByMemberNumber(memberNumber).getData() != null) {
+            return RsData.of(RsCode.F_06, "중복된 사원번호가 존재합니다.");
+        }
+
         Member member = Member.builder()
                 .department(od.get())
                 .grade(og.get())
@@ -74,6 +80,26 @@ public class MemberService {
         return RsData.of(RsCode.S_05, "회원을 찾았습니다.", om.get());
     }
 
+    // memberNumber(사원번호)로 회원 찾기
+    public RsData<Member> findByMemberNumber(Integer memberNumber) {
+        Optional<Member> om = this.memberRepository.findByMemberNumber(memberNumber);
+
+        if (om.isEmpty()) {
+            return RsData.of(RsCode.F_04, "회원이 존재하지 않습니다.", null);
+        }
+        return RsData.of(RsCode.S_05, "회원을 찾았습니다.", om.get());
+    }
+
+    // email로 회원 찾기
+    public RsData<Member> findByEmail(String email) {
+        Optional<Member> om = this.memberRepository.findByEmail(email);
+
+        if (om.isEmpty()) {
+            return RsData.of(RsCode.F_04, "회원이 존재하지 않습니다.", null);
+        }
+        return RsData.of(RsCode.S_05, "회원을 찾았습니다.", om.get());
+    }
+
     // 회원 수정
     public RsData<Member> update(Long id, Integer departmentCode, Integer gradeCode, String username,
                                  Integer memberNumber, String name, String password, String email) {
@@ -84,6 +110,14 @@ public class MemberService {
         // 존재하는 회원인지 검증
         if (rsData.getData() == null) {
             return RsData.of(rsData.getRsCode(), rsData.getMsg(), null);
+        }
+
+        if (findByUsername(username).getData() != null && findByUsername(username).getData().getId() != id) {
+            return RsData.of(RsCode.F_06, "중복된 아이디가 존재합니다.", null);
+        } else if (findByMemberNumber(memberNumber).getData() != null && findByMemberNumber(memberNumber).getData().getId() != id) {
+            return RsData.of(RsCode.F_06, "중복된 사원번호가 존재합니다.", null);
+        } else if (findByEmail(email).getData() != null && findByEmail(email).getData().getId() != id) {
+            return RsData.of(RsCode.F_06, "중복된 이메일이 존재합니다.", null);
         }
 
         Member member = rsData.getData().toBuilder()
@@ -114,7 +148,7 @@ public class MemberService {
     public RsData<String> refreshAccessToken(String refreshToken) {
         Optional<Member> om = this.memberRepository.findByRefreshToken(refreshToken);
 
-        if (om.isEmpty()){
+        if (om.isEmpty()) {
             return RsData.of(RsCode.F_04, "리프레시 토큰이 존재하지 않습니다.", null);
         }
         Member member = om.get();
@@ -153,8 +187,8 @@ public class MemberService {
             return RsData.of(RsCode.F_04, "잘못된 ID 또는 비밀번호 입니다.", null);
         }
 
-        if(!passwordEncoder.matches(password,om.get().getPassword())){
-            return RsData.of(RsCode.F_02,"잘못된 ID 또는 비밀번호 입니다.",null);
+        if (!passwordEncoder.matches(password, om.get().getPassword())) {
+            return RsData.of(RsCode.F_02, "잘못된 ID 또는 비밀번호 입니다.", null);
         }
 
         Member member = om.get();
@@ -166,7 +200,7 @@ public class MemberService {
 
         System.out.println("accessToken : " + accessToken);
 
-        return RsData.of(RsCode.S_06, "로그인에 성공했습니다.", new MemberResponse.AuthAndMakeTokensResponseBody(member, accessToken,refreshToken));
+        return RsData.of(RsCode.S_06, "로그인에 성공했습니다.", new MemberResponse.AuthAndMakeTokensResponseBody(member, accessToken, refreshToken));
     }
 
 }

--- a/src/main/java/com/app/businessBridge/domain/member/Service/MemberService.java
+++ b/src/main/java/com/app/businessBridge/domain/member/Service/MemberService.java
@@ -1,7 +1,7 @@
 package com.app.businessBridge.domain.member.Service;
 
 import com.app.businessBridge.domain.department.entity.Department;
-import com.app.businessBridge.domain.department.service.DepartmentService;
+import com.app.businessBridge.domain.department.repository.DepartmentRepository;
 import com.app.businessBridge.domain.grade.entity.Grade;
 import com.app.businessBridge.domain.grade.service.GradeService;
 import com.app.businessBridge.domain.member.entity.Member;
@@ -28,25 +28,18 @@ import java.util.Optional;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
-    private final DepartmentService departmentService;
+    private final DepartmentRepository departmentRepository;
     private final GradeService gradeService;
     private final JwtProvider jwtProvider;
 
     // 회원 생성
-    public RsData create(Long departmentId, Long gradeId, String username,
+    public RsData create(Integer departmentCode, Long gradeId, String username,
                          Integer memberNumber, String name, String password, String email) {
-        RsData<Department> departmentRsData = this.departmentService.findById(departmentId);
+        Optional<Department> od = this.departmentRepository.findByCode(departmentCode);
         RsData<Grade> gradeRsData = this.gradeService.findById(gradeId);
 
-        // 존재하는 부서, 직급인지 검증하는 if 문
-        if (departmentRsData.getData() == null) {
-            return RsData.of(departmentRsData.getRsCode(), departmentRsData.getMsg());
-        } else if (gradeRsData.getData() == null) {
-            return RsData.of(gradeRsData.getRsCode(), gradeRsData.getMsg());
-        }
-
         Member member = Member.builder()
-                .department(departmentRsData.getData())
+                .department(od.get())
                 .grade(gradeRsData.getData())
                 .username(username)
                 .memberNumber(memberNumber)
@@ -81,23 +74,19 @@ public class MemberService {
     }
 
     // 회원 수정
-    public RsData<Member> update(Long id, Long departmentId, Long gradeId, String username,
+    public RsData<Member> update(Long id, Integer departmentCode, Long gradeId, String username,
                                  Integer memberNumber, String name, String password, String email) {
         RsData<Member> rsData = findById(id);
-        RsData<Department> departmentRsData = this.departmentService.findById(departmentId);
+        Optional<Department> od = this.departmentRepository.findByCode(departmentCode);
         RsData<Grade> gradeRsData = this.gradeService.findById(gradeId);
 
-        // 존재하는 회원, 부서, 직급인지 검증하는 if 문
+        // 존재하는 회원인지 검증
         if (rsData.getData() == null) {
             return RsData.of(rsData.getRsCode(), rsData.getMsg(), null);
-        } else if (departmentRsData.getData() == null) {
-            return RsData.of(departmentRsData.getRsCode(), departmentRsData.getMsg(), null);
-        } else if (gradeRsData.getData() == null) {
-            return RsData.of(gradeRsData.getRsCode(), gradeRsData.getMsg(), null);
         }
 
         Member member = rsData.getData().toBuilder()
-                .department(departmentRsData.getData())
+                .department(od.get())
                 .grade(gradeRsData.getData())
                 .username(username)
                 .memberNumber(memberNumber)

--- a/src/main/java/com/app/businessBridge/domain/member/Service/MemberService.java
+++ b/src/main/java/com/app/businessBridge/domain/member/Service/MemberService.java
@@ -3,6 +3,7 @@ package com.app.businessBridge.domain.member.Service;
 import com.app.businessBridge.domain.department.entity.Department;
 import com.app.businessBridge.domain.department.repository.DepartmentRepository;
 import com.app.businessBridge.domain.grade.entity.Grade;
+import com.app.businessBridge.domain.grade.repository.GradeRepository;
 import com.app.businessBridge.domain.grade.service.GradeService;
 import com.app.businessBridge.domain.member.entity.Member;
 import com.app.businessBridge.domain.member.repository.MemberRepository;
@@ -29,18 +30,18 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final DepartmentRepository departmentRepository;
-    private final GradeService gradeService;
+    private final GradeRepository gradeRepository;
     private final JwtProvider jwtProvider;
 
     // 회원 생성
-    public RsData create(Integer departmentCode, Long gradeId, String username,
+    public RsData create(Integer departmentCode, Integer gradeCode, String username,
                          Integer memberNumber, String name, String password, String email) {
         Optional<Department> od = this.departmentRepository.findByCode(departmentCode);
-        RsData<Grade> gradeRsData = this.gradeService.findById(gradeId);
+        Optional<Grade> og = this.gradeRepository.findByCode(gradeCode);
 
         Member member = Member.builder()
                 .department(od.get())
-                .grade(gradeRsData.getData())
+                .grade(og.get())
                 .username(username)
                 .memberNumber(memberNumber)
                 .name(name)
@@ -74,11 +75,11 @@ public class MemberService {
     }
 
     // 회원 수정
-    public RsData<Member> update(Long id, Integer departmentCode, Long gradeId, String username,
+    public RsData<Member> update(Long id, Integer departmentCode, Integer gradeCode, String username,
                                  Integer memberNumber, String name, String password, String email) {
         RsData<Member> rsData = findById(id);
         Optional<Department> od = this.departmentRepository.findByCode(departmentCode);
-        RsData<Grade> gradeRsData = this.gradeService.findById(gradeId);
+        Optional<Grade> og = this.gradeRepository.findByCode(gradeCode);
 
         // 존재하는 회원인지 검증
         if (rsData.getData() == null) {
@@ -87,7 +88,7 @@ public class MemberService {
 
         Member member = rsData.getData().toBuilder()
                 .department(od.get())
-                .grade(gradeRsData.getData())
+                .grade(og.get())
                 .username(username)
                 .memberNumber(memberNumber)
                 .name(name)

--- a/src/main/java/com/app/businessBridge/domain/member/controller/ApiV1MemberController.java
+++ b/src/main/java/com/app/businessBridge/domain/member/controller/ApiV1MemberController.java
@@ -7,12 +7,9 @@ import com.app.businessBridge.domain.member.request.MemberRequest;
 import com.app.businessBridge.domain.member.response.MemberResponse;
 import com.app.businessBridge.global.RsData.RsCode;
 import com.app.businessBridge.global.RsData.RsData;
-import com.app.businessBridge.global.exception.GlobalException;
 import com.app.businessBridge.global.request.Request;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseCookie;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,16 +22,16 @@ public class ApiV1MemberController {
 
     // 멤버 생성
     @PostMapping("/signup")
-    public RsData<MemberResponse.GetMember> signup(@Valid @RequestBody MemberRequest.CreateRequset createRequset,
+    public RsData<MemberResponse.GetMember> signup(@Valid @RequestBody MemberRequest.CreateRequest createRequest,
                                                    BindingResult bindingResult) {
 
         if (bindingResult.hasErrors()) {
             return RsData.of(RsCode.F_10, "알 수 없는 오류로 실패했습니다.");
         }
 
-        RsData<Member> rsData = this.memberService.create(createRequset.getDepartmentId(), createRequset.getGradeId(),
-                createRequset.getUsername(), createRequset.getMemberNumber(), createRequset.getName(),
-                createRequset.getPassword(), createRequset.getEmail());
+        RsData<Member> rsData = this.memberService.create(createRequest.getDepartmentCode(), createRequest.getGradeId(),
+                createRequest.getUsername(), createRequest.getMemberNumber(), createRequest.getName(),
+                createRequest.getPassword(), createRequest.getEmail());
 
         return RsData.of(rsData.getRsCode(), rsData.getMsg(), new MemberResponse.GetMember(rsData.getData()));
     }
@@ -71,7 +68,7 @@ public class ApiV1MemberController {
         if (bindingResult.hasErrors()) {
             return RsData.of(RsCode.F_10, "알 수 없는 오류로 실패했습니다.");
         }
-        RsData<Member> rsData = this.memberService.update(updateRequest.getId(), updateRequest.getDepartmentId(), updateRequest.getGradeId(),
+        RsData<Member> rsData = this.memberService.update(updateRequest.getId(), updateRequest.getDepartmentcode(), updateRequest.getGradeId(),
                 updateRequest.getUsername(), updateRequest.getMemberNumber(), updateRequest.getName(),
                 updateRequest.getPassword(), updateRequest.getEmail());
 

--- a/src/main/java/com/app/businessBridge/domain/member/controller/ApiV1MemberController.java
+++ b/src/main/java/com/app/businessBridge/domain/member/controller/ApiV1MemberController.java
@@ -90,4 +90,11 @@ public class ApiV1MemberController {
         return RsData.of(rsData.getRsCode(), rsData.getMsg());
     }
 
+    @GetMapping("/me")
+    public RsData<MemberResponse.GetMember> memberMe(){
+        if(rq.getMember()==null){
+            return RsData.of(RsCode.F_02,"로그아웃 상태입니다.",null);
+        }
+        return RsData.of(RsCode.S_06, "로그인 상태 입니다.",new MemberResponse.GetMember(rq.getMember()));
+    }
 }

--- a/src/main/java/com/app/businessBridge/domain/member/controller/ApiV1MemberController.java
+++ b/src/main/java/com/app/businessBridge/domain/member/controller/ApiV1MemberController.java
@@ -29,7 +29,7 @@ public class ApiV1MemberController {
             return RsData.of(RsCode.F_10, "알 수 없는 오류로 실패했습니다.");
         }
 
-        RsData<Member> rsData = this.memberService.create(createRequest.getDepartmentCode(), createRequest.getGradeId(),
+        RsData<Member> rsData = this.memberService.create(createRequest.getDepartmentCode(), createRequest.getGradeCode(),
                 createRequest.getUsername(), createRequest.getMemberNumber(), createRequest.getName(),
                 createRequest.getPassword(), createRequest.getEmail());
 
@@ -68,7 +68,7 @@ public class ApiV1MemberController {
         if (bindingResult.hasErrors()) {
             return RsData.of(RsCode.F_10, "알 수 없는 오류로 실패했습니다.");
         }
-        RsData<Member> rsData = this.memberService.update(updateRequest.getId(), updateRequest.getDepartmentcode(), updateRequest.getGradeId(),
+        RsData<Member> rsData = this.memberService.update(updateRequest.getId(), updateRequest.getDepartmentcode(), updateRequest.getGradeCode(),
                 updateRequest.getUsername(), updateRequest.getMemberNumber(), updateRequest.getName(),
                 updateRequest.getPassword(), updateRequest.getEmail());
 

--- a/src/main/java/com/app/businessBridge/domain/member/controller/ApiV1MemberController.java
+++ b/src/main/java/com/app/businessBridge/domain/member/controller/ApiV1MemberController.java
@@ -21,8 +21,8 @@ public class ApiV1MemberController {
     private final Request rq;
 
     // 멤버 생성
-    @PostMapping("/signup")
-    public RsData<MemberResponse.GetMember> signup(@Valid @RequestBody MemberRequest.CreateRequest createRequest,
+    @PostMapping("")
+    public RsData signup(@Valid @RequestBody MemberRequest.CreateRequest createRequest,
                                                    BindingResult bindingResult) {
 
         if (bindingResult.hasErrors()) {
@@ -33,7 +33,7 @@ public class ApiV1MemberController {
                 createRequest.getUsername(), createRequest.getMemberNumber(), createRequest.getName(),
                 createRequest.getPassword(), createRequest.getEmail());
 
-        return RsData.of(rsData.getRsCode(), rsData.getMsg(), new MemberResponse.GetMember(rsData.getData()));
+        return RsData.of(rsData.getRsCode(),rsData.getMsg());
     }
 
     // 멤버 로그인
@@ -68,10 +68,13 @@ public class ApiV1MemberController {
         if (bindingResult.hasErrors()) {
             return RsData.of(RsCode.F_10, "알 수 없는 오류로 실패했습니다.");
         }
-        RsData<Member> rsData = this.memberService.update(updateRequest.getId(), updateRequest.getDepartmentcode(), updateRequest.getGradeCode(),
+        RsData<Member> rsData = this.memberService.update(updateRequest.getId(), updateRequest.getDepartmentCode(), updateRequest.getGradeCode(),
                 updateRequest.getUsername(), updateRequest.getMemberNumber(), updateRequest.getName(),
                 updateRequest.getPassword(), updateRequest.getEmail());
 
+        if(rsData.getData()==null){
+            return RsData.of(rsData.getRsCode(),rsData.getMsg());
+        }
         return RsData.of(rsData.getRsCode(), rsData.getMsg(), new MemberResponse.PatchedMember(rsData.getData()));
     }
 

--- a/src/main/java/com/app/businessBridge/domain/member/entity/Member.java
+++ b/src/main/java/com/app/businessBridge/domain/member/entity/Member.java
@@ -22,7 +22,7 @@ import lombok.experimental.SuperBuilder;
 public class Member extends BaseEntity {
     @ManyToOne
     private Department department; // 부서
-    @OneToOne
+    @ManyToOne
     private Grade grade; // 직급
     private String username; // 로그인 아이디
     private String password; // 비밀번호

--- a/src/main/java/com/app/businessBridge/domain/member/entity/Member.java
+++ b/src/main/java/com/app/businessBridge/domain/member/entity/Member.java
@@ -4,6 +4,7 @@ import com.app.businessBridge.domain.department.entity.Department;
 import com.app.businessBridge.domain.grade.entity.Grade;
 import com.app.businessBridge.domain.workingstate.entity.WorkingState;
 import com.app.businessBridge.global.Jpa.BaseEntity;
+import com.app.businessBridge.global.image.entity.Image;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -19,39 +20,33 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Member extends BaseEntity {
-
-    // 부서
     @ManyToOne
-    private Department department;
-
-    // 직급
+    private Department department; // 부서
     @OneToOne
-    private Grade grade;
+    private Grade grade; // 직급
+    private String username; // 로그인 아이디
+    private String password; // 비밀번호
+    private String email; // 이메일
 
-    // 로그인 아이디
-    private String username;
-
-    // 사원번호
-    private Integer memberNumber;
-
-    // 사원명
-    private String name;
-
-    // 비밀번호
-    private String password;
-
-    // 이메일
-    private String email;
-
-    // 리프레시 토큰
-    private String refreshToken;
+    @OneToOne
+    private Image profileImg; // 프로필 사진
+    private Integer memberNumber; // 사원번호
+    private String name; // 사원명
+    private String assignedTask; // 담당 업무
+    private String workStatus; // 근무 상태 ( 온라인, 오프라인, 부재중 )
+    private String extensionNumber; // 내선 전화 번호
+    private String phoneNumber; // 개인 연락처
+    private String statusMessage; // 상태메세지
 
     // 직원 근태
     @OneToOne(mappedBy = "member",cascade = CascadeType.REMOVE)
     @JoinColumn(name = "working_state_id")
     @JsonIgnore
     private WorkingState workingState;
-
     // 연봉 > 정산 시 필요
     private Long salary;
+
+
+    // 리프레시 토큰
+    private String refreshToken;
 }

--- a/src/main/java/com/app/businessBridge/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/app/businessBridge/domain/member/repository/MemberRepository.java
@@ -8,4 +8,8 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUsername(String username);
     Optional<Member> findByRefreshToken(String refreshToken);
+
+    Optional<Member> findByMemberNumber(Integer memberNumber);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/app/businessBridge/domain/member/request/MemberRequest.java
+++ b/src/main/java/com/app/businessBridge/domain/member/request/MemberRequest.java
@@ -14,7 +14,7 @@ public class MemberRequest {
         @NotNull
         private Integer departmentCode;
         @NotNull
-        private Long gradeId;
+        private Integer gradeCode;
         @NotBlank
         private String username;
         @NotNull
@@ -35,7 +35,7 @@ public class MemberRequest {
         @NotNull
         private Integer departmentcode;
         @NotNull
-        private Long gradeId;
+        private Integer gradeCode;
         @NotBlank
         private String username;
         @NotNull

--- a/src/main/java/com/app/businessBridge/domain/member/request/MemberRequest.java
+++ b/src/main/java/com/app/businessBridge/domain/member/request/MemberRequest.java
@@ -10,9 +10,9 @@ public class MemberRequest {
 
     @Getter
     @Setter
-    public static class CreateRequset {
+    public static class CreateRequest {
         @NotNull
-        private Long departmentId;
+        private Integer departmentCode;
         @NotNull
         private Long gradeId;
         @NotBlank
@@ -33,7 +33,7 @@ public class MemberRequest {
         @NotNull
         private Long id;
         @NotNull
-        private Long departmentId;
+        private Integer departmentcode;
         @NotNull
         private Long gradeId;
         @NotBlank

--- a/src/main/java/com/app/businessBridge/domain/member/request/MemberRequest.java
+++ b/src/main/java/com/app/businessBridge/domain/member/request/MemberRequest.java
@@ -33,7 +33,7 @@ public class MemberRequest {
         @NotNull
         private Long id;
         @NotNull
-        private Integer departmentcode;
+        private Integer departmentCode;
         @NotNull
         private Integer gradeCode;
         @NotBlank

--- a/src/main/java/com/app/businessBridge/domain/member/response/MemberResponse.java
+++ b/src/main/java/com/app/businessBridge/domain/member/response/MemberResponse.java
@@ -2,11 +2,8 @@ package com.app.businessBridge.domain.member.response;
 
 import com.app.businessBridge.domain.member.DTO.MemberDTO;
 import com.app.businessBridge.domain.member.entity.Member;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/app/businessBridge/domain/rebate/dto/RebateDto.java
+++ b/src/main/java/com/app/businessBridge/domain/rebate/dto/RebateDto.java
@@ -40,8 +40,8 @@ public class RebateDto {
     public RebateDto(Rebate rebate, Member member) {
         this.memberName = member.getName();
         this.memberId = String.valueOf(member.getMemberNumber());
-        this.grade = member.getGrade().getGradeName();
-        this.dept = member.getDepartment().getDepartmentName();
+        this.grade = member.getGrade().getName();
+        this.dept = member.getDepartment().getName();
 
         this.salary = rebate.getSalary();
         this.bonus = rebate.getBonus();;

--- a/src/main/java/com/app/businessBridge/global/initData/NotProd.java
+++ b/src/main/java/com/app/businessBridge/global/initData/NotProd.java
@@ -39,9 +39,9 @@ public class NotProd {
             gradeService.create(1002, "대리");
 
             // 회원 생성
-            memberService.create(1L, 1L, "admin", 10001, "김관리", "1234", "admin@email.com");
-            memberService.create(2L, 2L, "user1", 20001, "이마부", "1234", "user1@email.com");
-            memberService.create(3L, 3L, "user2", 30001, "박영대", "1234", "user2@email.com");
+            memberService.create(1, 1L, "admin", 10001, "김관리", "1234", "admin@email.com");
+            memberService.create(101, 2L, "user1", 20001, "이마부", "1234", "user1@email.com");
+            memberService.create(102, 3L, "user2", 30001, "박영대", "1234", "user2@email.com");
 
             chattingRoomService.create("채팅방1", memberService.findByUsername("admin").getData());
             chattingRoomService.create("채팅방2", memberService.findByUsername("admin").getData());

--- a/src/main/java/com/app/businessBridge/global/initData/NotProd.java
+++ b/src/main/java/com/app/businessBridge/global/initData/NotProd.java
@@ -39,9 +39,9 @@ public class NotProd {
             gradeService.create(1002, "대리");
 
             // 회원 생성
-            memberService.create(1, 1L, "admin", 10001, "김관리", "1234", "admin@email.com");
-            memberService.create(101, 2L, "user1", 20001, "이마부", "1234", "user1@email.com");
-            memberService.create(102, 3L, "user2", 30001, "박영대", "1234", "user2@email.com");
+            memberService.create(1, 1, "admin", 10001, "김관리", "1234", "admin@email.com");
+            memberService.create(101, 1001, "user1", 20001, "이마부", "1234", "user1@email.com");
+            memberService.create(102, 1002, "user2", 30001, "박영대", "1234", "user2@email.com");
 
             chattingRoomService.create("채팅방1", memberService.findByUsername("admin").getData());
             chattingRoomService.create("채팅방2", memberService.findByUsername("admin").getData());

--- a/src/main/java/com/app/businessBridge/global/request/Request.java
+++ b/src/main/java/com/app/businessBridge/global/request/Request.java
@@ -36,6 +36,11 @@ public class Request {
     public String getCookie(String name) {
         Cookie[] cookies = req.getCookies();
 
+        if (cookies == null) {
+            // 쿠키가 없는 경우 처리합니다.
+            return "";
+        }
+
         return Arrays.stream(cookies)
                 .filter(cookie -> cookie.getName().equals(name))
                 .findFirst()


### PR DESCRIPTION
### 🔎 작업 내용

-  Member 엔티티 속성 추가

-  department 엔티티 생성 시 ,수정 시 중복 유효성 검증

-  grade 엔티티 생성 시 ,수정 시 중복 유효성 검증

-  member 엔티티 생성 시 ,수정 시 중복 유효성 검증

### 👀 특이사항(필요 시 사용)

- 백 엔드 member/ApiV1MembersController 에 getMapping members/me 추가 했습니다.

- 프론트 엔드에 components/Api/MeApiWithReactQuery 로 페이지 새로고침 시에 캐싱된 query 데이터가 날아가지 않게 했습니다.

- 비 로그인 시 로그인 창 강제이동, 로그인 시 로그인 페이지 이동할 때 홈으로 강제 이동 시켰습니다.

<br/>
