### PR TITLE
PR#72 - [김대호] 로그아웃 추가 및, 프론트 멤버 정보 부분 데이터 삽입

### DIFF
--- a/front/src/app/auth/signin/page.tsx
+++ b/front/src/app/auth/signin/page.tsx
@@ -20,7 +20,7 @@ const SignIn: React.FC = () => {
   const router = useRouter();
 
   // 로그인 상태일때, 홈으로 돌려 보냄.
-  if (queryClient.getQueryData(["member"]) !== undefined) {
+  if (queryClient.getQueryData(["member"]) != null) {
     alert("이미 로그인 상태 입니다.");
     router.replace("/");
   }

--- a/front/src/components/Header/DropdownUser.tsx
+++ b/front/src/components/Header/DropdownUser.tsx
@@ -9,6 +9,7 @@ const DropdownUser = () => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const queryClient = useQueryClient();
   const router = useRouter();
+  const member = queryClient.getQueryData(["member"]);
 
   const trigger = useRef<any>(null);
   const dropdown = useRef<any>(null);
@@ -39,6 +40,7 @@ const DropdownUser = () => {
     return () => document.removeEventListener("keydown", keyHandler);
   });
 
+  // 로그아웃
   const logout = async () => {
     await api.post("/api/v1/members/logout").then((res) => {
       console.log(res.data.isSuccess);
@@ -50,6 +52,8 @@ const DropdownUser = () => {
     router.replace("/auth/signin");
   };
 
+  console.log(member);
+
   return (
     <div className="relative">
       <Link
@@ -60,9 +64,11 @@ const DropdownUser = () => {
       >
         <span className="hidden text-right lg:block">
           <span className="block text-sm font-medium text-black dark:text-white">
-            Thomas Anree
+            {member.name}
           </span>
-          <span className="block text-xs">UX Designer</span>
+          <span className="block text-xs">
+            {member.department.name} 부서 / {member.grade.name}
+          </span>
         </span>
 
         <span className="h-12 w-12 rounded-full">

--- a/front/src/components/Header/DropdownUser.tsx
+++ b/front/src/components/Header/DropdownUser.tsx
@@ -1,9 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import api from "@/util/api";
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 
 const DropdownUser = () => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const router = useRouter();
 
   const trigger = useRef<any>(null);
   const dropdown = useRef<any>(null);
@@ -33,6 +38,17 @@ const DropdownUser = () => {
     document.addEventListener("keydown", keyHandler);
     return () => document.removeEventListener("keydown", keyHandler);
   });
+
+  const logout = async () => {
+    await api.post("/api/v1/members/logout").then((res) => {
+      console.log(res.data.isSuccess);
+      if (res.data.isSuccess) {
+        queryClient.setQueryData(["member"], null);
+        alert(res.data.msg);
+      }
+    });
+    router.replace("/auth/signin");
+  };
 
   return (
     <div className="relative">
@@ -161,7 +177,10 @@ const DropdownUser = () => {
             </Link>
           </li>
         </ul>
-        <button className="flex items-center gap-3.5 px-6 py-4 text-sm font-medium duration-300 ease-in-out hover:text-primary lg:text-base">
+        <button
+          onClick={logout}
+          className="flex items-center gap-3.5 px-6 py-4 text-sm font-medium duration-300 ease-in-out hover:text-primary lg:text-base"
+        >
           <svg
             className="fill-current"
             width="22"

--- a/front/src/components/Header/DropdownUser.tsx
+++ b/front/src/components/Header/DropdownUser.tsx
@@ -5,11 +5,21 @@ import api from "@/util/api";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
+interface memberInfo {
+  name: String;
+  department: {
+    name: String;
+  };
+  grade: {
+    name: String;
+  };
+}
+
 const DropdownUser = () => {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const queryClient = useQueryClient();
   const router = useRouter();
-  const member = queryClient.getQueryData(["member"]);
+  const member = queryClient.getQueryData<memberInfo>(["member"]);
 
   const trigger = useRef<any>(null);
   const dropdown = useRef<any>(null);
@@ -64,10 +74,10 @@ const DropdownUser = () => {
       >
         <span className="hidden text-right lg:block">
           <span className="block text-sm font-medium text-black dark:text-white">
-            {member.name}
+            {member?.name}
           </span>
           <span className="block text-xs">
-            {member.department.name} 부서 / {member.grade.name}
+            {member?.department.name} 부서 / {member?.grade.name}
           </span>
         </span>
 

--- a/front/src/components/Layouts/DefaultLayout.tsx
+++ b/front/src/components/Layouts/DefaultLayout.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import React, { useState, ReactNode } from "react";
 import Sidebar from "@/components/Sidebar";
 import Header from "@/components/Header";

--- a/src/main/java/com/app/businessBridge/domain/member/controller/ApiV1MemberController.java
+++ b/src/main/java/com/app/businessBridge/domain/member/controller/ApiV1MemberController.java
@@ -53,6 +53,19 @@ public class ApiV1MemberController {
                 new MemberResponse.LoginResponse(new MemberDTO(authAndMakeTokensRsData.getData().getMember())));
     }
 
+    @PostMapping("/logout")
+    public RsData logout() {
+        try{
+            rq.removeCrossDomainCookie("accessToken");
+            rq.removeCrossDomainCookie("refreshToken");
+        }catch (Exception e){
+            return RsData.of(RsCode.F_07,"로그아웃에 실패했습니다.");
+        }
+
+
+        return RsData.of(RsCode.S_07, "로그아웃되었습니다.");
+    }
+
     // 멤버 단건 조회
     @GetMapping("/{id}")
     public RsData<MemberResponse.GetMember> getMember(@PathVariable(value = "id") Long id) {

--- a/src/main/java/com/app/businessBridge/global/request/Request.java
+++ b/src/main/java/com/app/businessBridge/global/request/Request.java
@@ -60,6 +60,17 @@ public class Request {
         resp.addHeader("Set-Cookie", cookie.toString());
     }
 
+    public void removeCrossDomainCookie(String name) {
+        ResponseCookie cookie = ResponseCookie.from(name, null)
+                .path("/")
+                .maxAge(0)
+                .sameSite("None")
+                .secure(true)
+                .httpOnly(true)
+                .build();
+        resp.addHeader("Set-Cookie", cookie.toString());
+    }
+
     public void setLogin(SecurityUser securityUser) {
         SecurityContextHolder.getContext().setAuthentication(securityUser.genAuthentication());
     }


### PR DESCRIPTION
### 🔎 작업 내용

- 백엔드 : 로그아웃 로직 추가 (쿠키의 token값 없애기)
- 프론트 엔드 : 로그아웃 버튼 api 요청 추가 (ReactQuery의 member캐싱 데이터 null 만들기)

### 👀 특이사항(필요 시 사용)

- 로그인 상태일 시 헤더 부분에 유저 데이터 삽입 했습니다. (사원명, 부서, 직급)
